### PR TITLE
Add new env var for browser preference and respect browser choice for interactive logins.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -211,10 +211,21 @@ provided `pybritive` will use an internally generated passphrase unique to the m
 ## Home Directory
 By default, files that `pybritive` requires will be persisted to `~/.britive/`. 
 
-This can be overwritten by specifying environment variable `PYBRITIVE_HOME_DIR`. This should be a path to where
+This can be overwritten by specifying environment variable `PYBRITIVE_HOME_DIR`. This can be either one of the following choices to where
 the end user wants to persist the `.britive` directory. Note that `.britive` will still be created so do not specify
 that as part of the path.
 
+
+## Browser
+By default, `pybritive` will use the OS defined default for any actions that have browser interaction(s).
+
+This can be overwritten by specifying environment variable `PYBRITIVE_BROWSER`. This can either be a one of the choices listed for commands
+that have the `--browser` option/flag, or can be set to an open command for browsers not provided by the Python3 `webbrowser` module.
+
+Example:
+~~~bash
+export PYBRITIVE_BROWSER="open -a /Applications/Firefox\ Developer\ Edition.app %s"
+~~~
 
 ## Escaping
 If the name of an application, environment, or profile contains a `/` then that character must be properly escaped with a `\`.

--- a/src/pybritive/britive_cli.py
+++ b/src/pybritive/britive_cli.py
@@ -1053,7 +1053,7 @@ class BritiveCli:
         # but use the url to pop open a browser
         console_url = requests.Request('GET', url, params=params).prepare().url
 
-        browser = webbrowser.get(using=browser)
+        browser = webbrowser.get(using=os.getenv("PYBRITIVE_BROWSER", browser))
         browser.open(console_url)
 
     def request_disposition(self, request_id, decision):

--- a/src/pybritive/choices/browser.py
+++ b/src/pybritive/choices/browser.py
@@ -4,7 +4,6 @@ import click
 
 browser_choices = click.Choice(
     [
-        'default'
         'mozilla',
         'firefox',
         'windows-default',

--- a/src/pybritive/commands/login.py
+++ b/src/pybritive/commands/login.py
@@ -5,8 +5,8 @@ from ..options.britive_options import britive_options
 
 @click.command()
 @build_britive
-@britive_options(names='tenant,token,silent,passphrase,federation_provider')
-def login(ctx, tenant, token, silent, passphrase, federation_provider):
+@britive_options(names='tenant,token,silent,passphrase,federation_provider,browser')
+def login(ctx, tenant, token, silent, passphrase, federation_provider, browser):
     """Perform an interactive login to obtain temporary credentials.
 
     This only applies when an API token has not been specified via `--token,-T` or via environment variable

--- a/src/pybritive/helpers/credentials.py
+++ b/src/pybritive/helpers/credentials.py
@@ -46,12 +46,13 @@ def b64_encode_url_safe(value: bytes):
 
 # this base class expects self.credentials to be a dict - so sub classes need to convert to dict
 class CredentialManager:
-    def __init__(self, tenant_name: str, tenant_alias: str, cli: any, federation_provider: str = None):
+    def __init__(self, tenant_name: str, tenant_alias: str, cli: any, federation_provider: str = None, browser: str = os.getenv("PYBRITIVE_BROWSER")):
         self.cli = cli
         self.tenant = tenant_name
         self.alias = tenant_alias
         self.base_url = f'https://{Britive.parse_tenant(tenant_name)}'
         self.federation_provider = federation_provider
+        self.browser = browser
         self.session = None
 
         # not sure if we really need 32 random bytes or if any random string would work
@@ -90,8 +91,8 @@ class CredentialManager:
         self._setup_requests_session()
 
         try:
-            webbrowser.get()
-            webbrowser.open(url)
+            browser = webbrowser.get(using=self.browser)
+            browser.open(url)
         except webbrowser.Error:
             self.cli.print(
                 'No web browser found. Please manually navigate to the link below and authenticate.'


### PR DESCRIPTION
- `PYBRITIVE_BROWSER` will allow a user to specify a default browser option, as well as use non-standard `webbrowser` options.
- Add `browser` option to login, so it respects a user's specified option/flag.