### PR TITLE
updated option to -x for maxpolltime on checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ site/
 lock-test.py
 test.py
 
+# IDE
+.vscode/
+
 # C extensions
 *.so
 

--- a/src/pybritive/options/maxpolltime.py
+++ b/src/pybritive/options/maxpolltime.py
@@ -2,7 +2,7 @@ import click
 
 
 option = click.option(
-    '--maxpolltime', '-p',
+    '--maxpolltime', '-x',
     default=600,
     show_default=True,
     help='Maximum seconds to poll before exiting.'


### PR DESCRIPTION
Currently, there are two options on -p on checkout. "Passphrase" and "maxpolltime"
This removes a conflict with -p Passphrase.