### PR TITLE
Kube clear

### DIFF
--- a/src/pybritive/britive_cli.py
+++ b/src/pybritive/britive_cli.py
@@ -880,6 +880,10 @@ class BritiveCli:
     def cache_clear():
         Cache().clear()
 
+    @staticmethod
+    def cache_clear_kubeconfig():
+        Cache().clear_kubeconfig()
+
     def configure_update(self, section, field, value):
         self.config.update(section=section, field=field, value=value)
 

--- a/src/pybritive/commands/clear.py
+++ b/src/pybritive/commands/clear.py
@@ -19,8 +19,8 @@ def cache(ctx):
 @clear.command(name='kubeconfig')
 @build_britive
 def clear_kube(ctx):
-    ctx.obj.britive.cache_clear_kubeconfig()
     """Clears the local .britive/kube/config file."""
+    ctx.obj.britive.cache_clear_kubeconfig()
 
 
 @clear.command(name='gcloud-auth-key-files')

--- a/src/pybritive/commands/clear.py
+++ b/src/pybritive/commands/clear.py
@@ -16,6 +16,13 @@ def cache(ctx):
     ctx.obj.britive.cache_clear()
 
 
+@clear.command(name='kubeconfig')
+@build_britive
+def cache(ctx):
+    ctx.obj.britive.cache_clear_kubeconfig()
+    """Clears the local .britive/kube/config file."""
+
+
 @clear.command(name='gcloud-auth-key-files')
 @build_britive
 def gcloud_auth_key_files(ctx):

--- a/src/pybritive/commands/clear.py
+++ b/src/pybritive/commands/clear.py
@@ -18,7 +18,7 @@ def cache(ctx):
 
 @clear.command(name='kubeconfig')
 @build_britive
-def cache(ctx):
+def clear_kube(ctx):
     ctx.obj.britive.cache_clear_kubeconfig()
     """Clears the local .britive/kube/config file."""
 

--- a/src/pybritive/helpers/cache.py
+++ b/src/pybritive/helpers/cache.py
@@ -67,6 +67,15 @@ class Cache:
         except FileNotFoundError:
             pass
 
+    def clear_kubeconfig(self):
+        # delete kube config if it exists
+        kubeconfig = Path(self.base_path) / 'kube' / 'config'
+        # kubeconfig.unlink(missing_ok=True)
+        # removed for now, for 3.7 compatability
+        try:
+            kubeconfig.unlink()
+        except FileNotFoundError:
+            pass
 
     def get_credentials(self, profile_name: str, mode: str = 'awscredentialprocess'):
         try:


### PR DESCRIPTION
Adds an option to clear only pybritive created kubeconfig file.
When used, it safely clears out `.britive/kube/config file.`